### PR TITLE
Bump passage node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.env
+*node_modules/
+*.DS_STORE
+*package-lock.json

--- a/1-GCP-API-Gateway/README.md
+++ b/1-GCP-API-Gateway/README.md
@@ -56,7 +56,7 @@ Next, we need to make sure that the Passage Node SDK is accessible from within t
   "name": "user",
   "version": "0.0.1",
   "dependencies": {
-    "@passageidentity/passage-node": "^1.8.0"
+    "@passageidentity/passage-node": "^2.4.1"
   }
 }
 ```

--- a/1-GCP-API-Gateway/package-lock.json
+++ b/1-GCP-API-Gateway/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-example",
       "version": "0.1.0",
       "dependencies": {
-        "@passageidentity/passage-elements": "^0.1.0-beta.41",
+        "@passageidentity/passage-elements": "latest",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",

--- a/1-GCP-API-Gateway/supporting/cloud-function/package.json
+++ b/1-GCP-API-Gateway/supporting/cloud-function/package.json
@@ -2,6 +2,6 @@
     "name": "user",
     "version": "0.0.1",
     "dependencies": {
-      "@passageidentity/passage-node": "^1.8.0"
+      "@passageidentity/passage-node": "^2.4.1"
     }
   }


### PR DESCRIPTION
## Description
[passage-node](https://github.com/passageidentity/passage-node) is now on version 2.4.1. This PR updates the node example from version 1.3.0 to 2.4.1.